### PR TITLE
CI: Use Wrapped External Actions From `stacks-sbtc/actions` Repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,14 +15,18 @@ jobs:
         node-version: [18.x]
 
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Repository
+        id: checkout_repository
+        uses: stacks-sbtc/actions/checkout@main
 
-      - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v4
+      - name: Install Node.js ${{ matrix.node-version }}
+        id: install_node
+        uses: stacks-sbtc/actions/setup-node@main
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Build
+      - name: Yarn Build
+        id: yarn_build
         run: |
           yarn install --frozen-lockfile
           yarn build


### PR DESCRIPTION
This PR replaces the actions used in the workflows with the ones from `actions` repository. I've also added `name` and `id` to all steps of the jobs and applied formatting for consistency and readability.

This PR should only be merged after https://github.com/stacks-sbtc/actions/pull/2, as it is dependent on some of the modifications included there.